### PR TITLE
Moved from UIWebView to WKWebView

### DIFF
--- a/Conekta/Conekta.h
+++ b/Conekta/Conekta.h
@@ -13,12 +13,14 @@
 #import <Foundation/Foundation.h>
 #import "Token.h"
 #import "Card.h"
+#import <WebKit/WebKit.h>
 
 @interface Conekta : NSObject
 
 @property (nonatomic, retain) NSString *baseURI;
 @property (nonatomic, retain) NSString *publicKey;
 @property (nonatomic, retain) UIViewController *delegate;
+@property (strong, nonatomic) WKWebView *webView;
 
 - (NSString *) deviceFingerprint;
 - (void) collectDevice;

--- a/Conekta/Conekta.m
+++ b/Conekta/Conekta.m
@@ -25,10 +25,12 @@
 
 - (void) collectDevice {
     NSString *html = [NSString stringWithFormat:@"<html style=\"background: blue;\"><head></head><body><script type=\"text/javascript\" src=\"https://conektaapi.s3.amazonaws.com/v0.5.0/js/conekta.js\" data-conekta-public-key=\"%@\" data-conekta-session-id=\"%@\"></script></body></html>", [self publicKey], [self deviceFingerprint]];
-    UIWebView *web = [[UIWebView alloc] initWithFrame:CGRectMake(0, 0, 0, 0)];
-    [web loadHTMLString:html baseURL:nil];
-    [web setScalesPageToFit:YES];
-    [self.delegate.view addSubview:web];
+    WKWebViewConfiguration *theConfiguration = [[WKWebViewConfiguration alloc] init];
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 0, 0) configuration:theConfiguration];
+    NSURL *nsurl=[NSURL URLWithString:html];
+    NSURLRequest *nsrequest=[NSURLRequest requestWithURL:nsurl];
+    [webView loadRequest:nsrequest];
+    [self.delegate.view addSubview:webView];
 }
 
 - (id) populate: (id) class


### PR DESCRIPTION
Moved from UIWebView to WKWebView because UIWebView is no longer accepted by Apple:

ITMS-90809: Deprecated API Usage - App updates that use UIWebView will no longer be accepted as of December 2020. Instead, use WKWebView for improved security and reliability. Learn more (https://developer.apple.com/documentation/uikit/uiwebview).